### PR TITLE
Adds AdaGrad to learning.latent_sgd, and option for log loss

### DIFF
--- a/learning.py
+++ b/learning.py
@@ -6,13 +6,53 @@ __version__ = "0.9"
 __maintainer__ = "Bill MacCartney"
 __email__ = "See the author's website"
 
+import math
 import random
-from collections import defaultdict
+from collections import defaultdict, Counter
 
 from metrics import SemanticsAccuracyMetric, DenotationAccuracyMetric
-from scoring import Model
+from scoring import Model, score
 
-def latent_sgd(model=None, examples=[], training_metric=None, T=10, eta=0.1, seed=None):
+
+def latent_sgd(
+        model,
+        examples,
+        training_metric,
+        T=10,
+        eta=0.1,
+        seed=None,
+        loss='hinge',
+        l2_penalty=0.0,
+        epsilon=1e-7):
+    """
+    Parameters
+    ----------
+    model : `scoring.Model`
+    examples : iterable of `example.Example`
+    training_metric : `metric.Metric`
+    T : int
+        Maximum number of training instances. This can be cut short
+        if the error or AdaGrad magnitude drop below `epsilon`.
+    eta : float
+        Learning rate
+    seed : int or None
+        Use to fix the randomization in how examples are shuffled and
+        ties are decided.
+    loss : str
+        Either 'hinge' or 'log'.
+    l2_penalty : float
+        L2 penalty constant to apply to each weight. If 0.0, then
+        no penalty is imposed. Larger weights correspond to a stronger
+        penalty.
+    epsilon : float
+        Tolerance for stopping learning. If either the total error
+        or the adagrad magnitude drops below this, then learning
+        is terminated.
+
+    Returns
+    -------
+    Trained `scoring.Model` instance.
+    """
     # Used for sorting scored parses.
     def scored_parse_key_fn(scored_parse):
         return (scored_parse[0], str(scored_parse[1]))
@@ -25,9 +65,14 @@ def latent_sgd(model=None, examples=[], training_metric=None, T=10, eta=0.1, see
         print('random.seed(%d)' % seed)
         random.seed(seed)
     model = clone_model(model)
+    adagrad = defaultdict(float)
+    # No margin cost for log-loss objective:
+    costfunc = cost if loss == 'hinge' else (lambda x, y : 0.0)
     for t in range(T):
         random.shuffle(examples)
         num_correct = 0
+        ada_update_mag = 0.0
+        error = 0.0
         for example in examples:
             # Reparse with current weights.
             parses = model.parse_input(example.input)
@@ -36,15 +81,31 @@ def latent_sgd(model=None, examples=[], training_metric=None, T=10, eta=0.1, see
             if good_parses:
                 target_parse = good_parses[0]
                 # Get all (score, parse) pairs.
-                scores = [(p.score + cost(target_parse, p), p) for p in parses]
+                scores = [(p.score + costfunc(target_parse, p), p) for p in parses]
                 # Get the maximal score.
                 max_score = sorted(scores, key=scored_parse_key_fn)[-1][0]
+                # Error:
+                error += max_score - target_parse.score
                 # Get all the candidates with the max score and choose one randomly.
                 predicted_parse = random.choice([p for s, p in scores if s == max_score])
                 if training_metric.evaluate(example, [predicted_parse]):
                     num_correct += 1
-                update_weights(model, target_parse, predicted_parse, eta)
-        print('SGD iteration %d: train accuracy: %.3f' % (t, 1.0 * num_correct / len(examples)))
+                ada_update_mag, adagrad = update_weights(
+                    model,
+                    target_parse,
+                    predicted_parse,
+                    eta,
+                    l2_penalty,
+                    loss, adagrad,
+                    ada_update_mag)
+        acc = 1.0 * num_correct / len(examples)
+        print(
+            'iter. {0:}; '
+            'err. {1:0.07f}; '
+            'AdaGrad mag. {2:0.07f}; '
+            'train acc. {3:0.04f}'.format(t+1, error, ada_update_mag, acc))
+        if error < epsilon or ada_update_mag < epsilon:
+            break
     print_weights(model.weights)
     return model
 
@@ -57,15 +118,31 @@ def clone_model(model):
                  weights=defaultdict(float),  # Zero the weights.
                  executor=model.executor)
 
-def update_weights(model, target_parse, predicted_parse, eta):
+def update_weights(model, target_parse, predicted_parse, eta, l2_penalty, loss, adagrad, ada_update_mag):
     target_features = model.feature_fn(target_parse)
     predicted_features = model.feature_fn(predicted_parse)
-    for f in set(list(target_features.keys()) + list(predicted_features.keys())):
-        update = target_features[f] - predicted_features[f]
-        if update != 0.0:
-            # print 'update %g + %g * %g = %g\t%s' % (
-            #     model.weights[f], eta, update, model.weights[f] + eta * update, f)
-            model.weights[f] += eta * update
+    all_f = set(target_features.keys()) | set(predicted_features.keys())
+    # Gradient:
+    grad = defaultdict(float)
+    if loss == 'hinge':
+        for f in all_f:
+            grad[f] = target_features[f] - predicted_features[f]
+    else: # This is the log-loss:
+        grad = Counter(target_features)
+        grad.subtract(predicted_features)
+    # L2 penalty:
+    for f, w in model.weights.items():
+        grad[f] -= l2_penalty * w
+    # Adaptive gradient update:
+    for f, w in grad.items():
+        adagrad[f] += grad[f]**2
+        ada_decay = math.sqrt(adagrad[f])
+        if ada_decay != 0.0:
+            dw = eta * (grad[f] / ada_decay)
+            model.weights[f] += dw
+            ada_update_mag += dw**2
+    return (ada_update_mag, adagrad)
+
 
 def print_weights(weights, n=20):
     pairs = [(value, str(key)) for key, value in list(weights.items()) if value != 0]


### PR DESCRIPTION
This PR affects only learning.py: it adds AdaGrad to the SGD loop, and it creates an option for using a log loss instead of a hinge loss.

AdaGrad seems to speed up learning in a way that will help students develop faster.

The log-loss gives them another option to explore. In my experience, very informally, log-loss delivers higher accuracy but is less likely to deliver weights that let us induce the desired grammar.