### PR TITLE
Accuracy based on the best parse

### DIFF
--- a/learning.py
+++ b/learning.py
@@ -88,7 +88,7 @@ def latent_sgd(
                 error += max_score - target_parse.score
                 # Get all the candidates with the max score and choose one randomly.
                 predicted_parse = random.choice([p for s, p in scores if s == max_score])
-                if training_metric.evaluate(example, [predicted_parse]):
+                if training_metric.evaluate(example, parses):
                     num_correct += 1
                 ada_update_mag, adagrad = update_weights(
                     model,


### PR DESCRIPTION
This small change should help bring the accuracy results reported during training into better alignment with what we see at test time. The change just involves assessing based on the best current parse rather than the currently predicted one. I think the currently predicted one isn't really optimal because of the noisiness of SGD updates. Testing against the current best parse is more like what happens during testing.